### PR TITLE
feat: add cy.slowDown and cy.slowDownEnd commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,12 @@ You can slow down a part of your test by using the custom dual commands `cy.slow
 // cypress/e2e/spec.cy.js
 // https://github.com/bahmutov/cypress-slow-down
 import { slowCypressDown } from 'cypress-slow-down'
+// registers the cy.slowDown and cy.slowDownEnd commands
+import 'cypress-slow-down/commands'
+// must enable the plugin using slowCypressDown
 // can disable the slow down by default or use some default delay
 slowCypressDown(false)
+
 it('runs the middle part slowly', () => {
   cy.visit('/')
   cy.get('...').should('...').slowDown(1000)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ Because this plugin uses [cypress-plugin-config](https://github.com/bahmutov/cyp
 
 The re-run the tests by pressing the key "R" or clicking "Run All Tests" button.
 
+## Child commands
+
+You can slow down a part of your test by using the custom dual commands `cy.slowDown(ms)` and `cy.slowDownEnd()`.
+
+```js
+// your spec file
+// cypress/e2e/spec.cy.js
+// https://github.com/bahmutov/cypress-slow-down
+import { slowCypressDown } from 'cypress-slow-down'
+// can disable the slow down by default or use some default delay
+slowCypressDown(false)
+it('runs the middle part slowly', () => {
+  cy.visit('/')
+  cy.get('...').should('...').slowDown(1000)
+  // these commands have 1 second delay
+  ...
+  cy.slowDownEnd()
+  // back to the normal speed
+})
+```
+
 ## Small print
 
 Author: Gleb Bahmutov &lt;gleb.bahmutov@gmail.com&gt; &copy; 2022

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Slow down your Cypress tests
 
-Watch this plugin in the video [Slow Down Cypress Tests](https://youtu.be/lxx-_nAkQo8).
+Watch the introduction to this plugin in the video [Slow Down Cypress Tests](https://youtu.be/lxx-_nAkQo8). For advanced usage, see the lessons in my [Cypress Plugins course](https://cypress.tips/courses/cypress-plugins).
 
 ## Install
 

--- a/commands.js
+++ b/commands.js
@@ -1,0 +1,42 @@
+const {
+  setPluginConfigValue,
+  getPluginConfigValue,
+} = require('cypress-plugin-config')
+
+// stack of command delays so we can restore
+// any previous value correctly
+const commandDelays = []
+
+const key = 'commandDelay'
+
+Cypress.Commands.add(
+  'slowDown',
+  { prevSubject: 'optional' },
+  (subject, commandDelay) => {
+    // TODO: validate the input value
+    cy.log(`**slowDown ${commandDelay}**`)
+    commandDelays.push(getPluginConfigValue(key))
+    setPluginConfigValue(key, commandDelay)
+
+    if (subject) {
+      cy.wrap(subject, {
+        log: false,
+      })
+    }
+  },
+)
+
+Cypress.Commands.add('slowDownEnd', { prevSubject: 'optional' }, (subject) => {
+  if (!commandDelays.length) {
+    throw new Error('There was not slow down...')
+  }
+  cy.log(`**slowDownEnd**`)
+  const commandDelay = commandDelays.pop()
+  setPluginConfigValue(key, commandDelay)
+
+  if (subject) {
+    cy.wrap(subject, {
+      log: false,
+    })
+  }
+})

--- a/commands.js
+++ b/commands.js
@@ -13,7 +13,15 @@ Cypress.Commands.add(
   'slowDown',
   { prevSubject: 'optional' },
   (subject, commandDelay) => {
-    // TODO: validate the input value
+    if (typeof commandDelay !== 'number') {
+      throw new Error(`Expected a numerical command delay, got ${commandDelay}`)
+    }
+    if (commandDelay < 0) {
+      throw new Error(
+        `Time is linear (I think), the command delay cannot be negative, you passed ${commandDelay}`,
+      )
+    }
+
     cy.log(`**slowDown ${commandDelay}**`)
     commandDelays.push(getPluginConfigValue(key))
     setPluginConfigValue(key, commandDelay)

--- a/cypress/e2e/commands.cy.js
+++ b/cypress/e2e/commands.cy.js
@@ -1,5 +1,4 @@
 // @ts-check
-// @ts-ignore
 import { slowCypressDown } from '../..'
 import '../../commands'
 

--- a/cypress/e2e/commands.cy.js
+++ b/cypress/e2e/commands.cy.js
@@ -1,0 +1,35 @@
+// @ts-check
+// @ts-ignore
+import { slowCypressDown } from '../..'
+import '../../commands'
+
+// disable any slow down at first
+slowCypressDown(false)
+
+describe('TodoMVC', () => {
+  it('clears completed todos (slows down part of the test)', () => {
+    cy.visit('/todo')
+    cy.get('.todo-list li')
+      .should('have.length', 2)
+      .should('include.text', 'Pay electric bill')
+    cy.get('.new-todo').type('Write tests{enter}')
+    cy.get('.todo-list li').should('have.length', 3)
+    cy.contains('.todo-count', '3 items left').slowDown(1000)
+    // now each command should be delayed 1 second
+    cy.get('.todo-list li')
+      .first()
+      .find('.toggle')
+      .slowDown(3000)
+      // slow down each command by 3 seconds
+      .click()
+      .slowDownEnd()
+    // back to 1 second delays
+    cy.get('.todo-list li').first().should('have.class', 'completed')
+    cy.contains('.todo-count', '2 items left').slowDownEnd()
+    // back to no slow down
+    cy.get('button.clear-completed').click()
+    cy.get('.todo-list li')
+      .should('have.length', 2)
+      .should('not.include.text', 'Pay electric bill')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.0-development",
   "description": "Slow down your Cypress tests",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "files": [
-    "src"
+    "src",
+    "commands.js"
   ],
   "scripts": {
     "test": "cypress run",

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,17 @@
+// load type definitions that come with Cypress module
+// and then add our new commands to the "cy" object
+/// <reference types="cypress" />
+declare namespace Cypress {
+  interface Chainable {
+    /**
+     * Delays each command by N ms
+     * @param commandDelay number
+     * @see https://github.com/bahmutov/cypress-slow-down
+     */
+    slowDown(commandDelay: number): Chainable<any>
+    /**
+     * Ends any previous slow down
+     */
+    slowDownEnd(): Chainable<any>
+  }
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,17 @@
+// load type definitions that come with Cypress module
+// and then add our new commands to the "cy" object
+/// <reference types="cypress" />
+declare namespace Cypress {
+  interface Chainable {
+    /**
+     * Delays each command by N ms
+     * @param commandDelay number
+     * @see https://github.com/bahmutov/cypress-slow-down
+     */
+    slowDown(commandDelay: number): Chainable<any>
+    /**
+     * Ends any previous slow down
+     */
+    slowDownEnd(): Chainable<any>
+  }
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,17 +1,11 @@
-// load type definitions that come with Cypress module
-// and then add our new commands to the "cy" object
-/// <reference types="cypress" />
-declare namespace Cypress {
-  interface Chainable {
-    /**
-     * Delays each command by N ms
-     * @param commandDelay number
-     * @see https://github.com/bahmutov/cypress-slow-down
-     */
-    slowDown(commandDelay: number): Chainable<any>
-    /**
-     * Ends any previous slow down
-     */
-    slowDownEnd(): Chainable<any>
-  }
-}
+// import the custom Cypress commands provided by this module
+import * as globals from './globals'
+
+/**
+ * Slows down every Cypress command by the given amount.
+ * Can disable the slowdown by passing false.
+ * @example
+ *  import {slowCypressDown} from 'cypress-slow-down'
+ *  slowCypressDown(1000)
+ */
+export function slowCypressDown(ms: number | false): void

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,37 @@
 // for consistency, if we use CommonJS to export from this module
 // we should use CommonJS convention to import other dependencies
-const { getPluginConfigValue } = require('cypress-plugin-config')
+const {
+  setPluginConfigValue,
+  getPluginConfigValue,
+} = require('cypress-plugin-config')
+
+const key = 'commandDelay'
 
 function slowCypressDown(commandDelay) {
   if (typeof commandDelay === 'undefined') {
-    commandDelay = getPluginConfigValue('commandDelay')
+    commandDelay = getPluginConfigValue(key)
   }
   if (typeof commandDelay === 'undefined') {
     commandDelay = 1000
   }
 
-  if (commandDelay === false) {
-    // disabled command slow down
-    return
-  }
-
-  if (commandDelay < 0) {
+  if (typeof commandDelay === 'number' && commandDelay < 0) {
     throw new Error(
       `Time is linear (I think), the command delay cannot be negative, you passed ${commandDelay}`,
     )
   }
 
+  setPluginConfigValue(key, commandDelay)
   const rc = cy.queue.runCommand.bind(cy.queue)
   cy.queue.runCommand = function slowRunCommand(cmd) {
-    return Cypress.Promise.delay(commandDelay).then(() => rc(cmd))
+    // get the _current_ command delay, which could be changed
+    // using the child command slowDown(ms)
+    const currentCommandDelay = getPluginConfigValue(key) || commandDelay
+    console.log({ currentCommandDelay })
+    if (!currentCommandDelay) {
+      return rc(cmd)
+    }
+    return Cypress.Promise.delay(currentCommandDelay).then(() => rc(cmd))
   }
 }
 


### PR DESCRIPTION
You can slow down a part of your test by using the custom dual commands `cy.slowDown(ms)` and `cy.slowDownEnd()`.

```js
// your spec file
// cypress/e2e/spec.cy.js
// https://github.com/bahmutov/cypress-slow-down
import { slowCypressDown } from 'cypress-slow-down'
// registers the cy.slowDown and cy.slowDownEnd commands
import 'cypress-slow-down/commands'
// must enable the plugin using slowCypressDown
// can disable the slow down by default or use some default delay
slowCypressDown(false)

it('runs the middle part slowly', () => {
  cy.visit('/')
  cy.get('...').should('...').slowDown(1000)
  // these commands have 1 second delay
  ...
  cy.slowDownEnd()
  // back to the normal speed
})
```

also adds module TS definition which should resolve #2 