### PR TITLE
Adding option to disable logging to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ import { slowCypressDown } from 'cypress-slow-down'
 slowCypressDown() // slows down each command by 500ms
 ```
 
+You can set the optional `logToConsole` parameter to false to prevent the plugin from logging each delay to the console.
+
+```js
+slowCypressDown(1000, false)
+```
+
 ## Disable the slow down
 
 You can disable the default slowdown by using `false`. For example, from the command line you can pass the boolean value:

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,6 +1,6 @@
 import { slowCypressDown } from '../..'
 
-slowCypressDown()
+slowCypressDown(1000, false)
 
 describe('TodoMVC', () => {
   it('clears completed todos', () => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,4 +8,7 @@ import * as globals from './globals'
  *  import {slowCypressDown} from 'cypress-slow-down'
  *  slowCypressDown(1000)
  */
-export function slowCypressDown(ms?: number | false): void
+export function slowCypressDown(
+  ms?: number | false,
+  logToConsole?: boolean,
+): void

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const {
 
 const key = 'commandDelay'
 
-function slowCypressDown(commandDelay) {
+function slowCypressDown(commandDelay, logToConsole = true) {
   if (typeof commandDelay === 'undefined') {
     commandDelay = getPluginConfigValue(key)
   }
@@ -27,7 +27,9 @@ function slowCypressDown(commandDelay) {
     // get the _current_ command delay, which could be changed
     // using the child command slowDown(ms)
     const currentCommandDelay = getPluginConfigValue(key) || commandDelay
-    console.log({ currentCommandDelay })
+    if (logToConsole) {
+      console.log({ currentCommandDelay })
+    }
     if (!currentCommandDelay) {
       return rc(cmd)
     }


### PR DESCRIPTION
Addresses https://github.com/bahmutov/cypress-slow-down/issues/22

I didn't want to change existing behaviour, so I enabled logging by default